### PR TITLE
poc-import: bootstrap CLI, config/logging, and lint/type fixes (issues #71-#73)

### DIFF
--- a/tools/poc-import/README.md
+++ b/tools/poc-import/README.md
@@ -19,10 +19,15 @@ pip install -e ".[dev]"
 
 ## Usage
 
-You can run via the installed CLI or the local wrapper:
+You can run via the installed CLI or the local wrapper to start the interactive
+shell:
 
 ```bash
-./tools/poc-import/poc-import.py --help
+./tools/poc-import/poc-import.py
+```
+
+```bash
+poc-import
 ```
 
 ### Import MS Project XML (Initial)
@@ -53,6 +58,14 @@ poc-import msproject path/to/your/project.xml \
   --token=$WFP_JWT_TOKEN \
   --api-url=http://localhost:5000 \
   --dry-run
+```
+
+### Excel Imports (Scaffolded)
+
+```bash
+poc-import
+> excel expenses ./expenses.xlsx --project-id <project-uuid>
+> excel rae ./rae.xlsx --project-id <project-uuid>
 ```
 
 ## Environment Variables

--- a/tools/poc-import/pyproject.toml
+++ b/tools/poc-import/pyproject.toml
@@ -6,7 +6,7 @@ name = "poc-import"
 version = "1.0.0"
 description = "MS Project and Excel import service for wfp-poc API"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.11"
 license = {text = "Commercial"}
 authors = [
     {name = "Waterfall Team", email = "team@waterfall-services.io"},
@@ -16,10 +16,9 @@ classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 
 dependencies = [
@@ -84,7 +83,7 @@ addopts = [
 ]
 
 [tool.ruff]
-target-version = "py39"
+target-version = "py311"
 line-length = 88
 exclude = [
     ".git",
@@ -110,7 +109,7 @@ ignore = []
 known-first-party = ["poc_import"]
 
 [tool.mypy]
-python_version = "3.9"
+python_version = "3.11"
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = true

--- a/tools/poc-import/src/poc_import/api/client.py
+++ b/tools/poc-import/src/poc_import/api/client.py
@@ -5,7 +5,7 @@
 
 import logging
 import math
-from typing import Any, Optional
+from typing import Any
 
 import requests
 from requests.adapters import HTTPAdapter
@@ -28,8 +28,8 @@ class WfpApiError(Exception):
     def __init__(
         self,
         message: str,
-        status_code: Optional[int] = None,
-        response_data: Optional[dict[str, Any]] = None,
+        status_code: int | None = None,
+        response_data: dict[str, Any] | None = None,
     ):
         super().__init__(message)
         self.status_code = status_code
@@ -52,7 +52,7 @@ class WfpApiClient:
         base_url: str,
         token: str,
         correlation_id: str,
-        company_id: Optional[str] = None,
+        company_id: str | None = None,
         timeout: int = 30,
     ):
         """Initialize API client.
@@ -271,8 +271,8 @@ class WfpApiClient:
 
     def list_projects(
         self,
-        page: Optional[int] = None,
-        per_page: Optional[int] = None,
+        page: int | None = None,
+        per_page: int | None = None,
     ) -> dict[str, Any]:
         """List projects.
 
@@ -303,8 +303,8 @@ class WfpApiClient:
     def list_project_tasks(
         self,
         project_id: str,
-        page: Optional[int] = None,
-        per_page: Optional[int] = None,
+        page: int | None = None,
+        per_page: int | None = None,
     ) -> dict[str, Any]:
         """List tasks for a project.
 

--- a/tools/poc-import/src/poc_import/cli.py
+++ b/tools/poc-import/src/poc_import/cli.py
@@ -6,6 +6,7 @@
 import click
 from click_shell import shell
 
+from poc_import.commands.excel import excel
 from poc_import.commands.help_cmd import help_cmd
 from poc_import.commands.msproject import msproject
 from poc_import.commands.service import service
@@ -13,7 +14,7 @@ from poc_import.commands.xml import xml
 from poc_import.shell_state import ShellState
 
 
-@shell(prompt="> ")
+@shell(name="poc-import", prompt="> ")
 @click.version_option(version="1.0.0", prog_name="poc-import")
 @click.pass_context
 def cli(ctx: click.Context) -> None:
@@ -25,6 +26,7 @@ def cli(ctx: click.Context) -> None:
 cli.add_command(msproject)
 cli.add_command(xml)
 cli.add_command(service)
+cli.add_command(excel)
 cli.add_command(help_cmd)
 
 

--- a/tools/poc-import/src/poc_import/cli_support.py
+++ b/tools/poc-import/src/poc_import/cli_support.py
@@ -61,9 +61,11 @@ class CorrelationIdFilter(logging.Filter):
 
     def filter(self, record: logging.LogRecord) -> bool:
         record.correlation_id = get_correlation_id()
-        message = record.getMessage()
-        redacted = redact_secrets(message)
-        record.msg = redacted
+        # Format message with args before redaction to ensure args are included
+        formatted_message = record.getMessage()
+        redacted_message = redact_secrets(formatted_message)
+        # Replace msg with redacted formatted message and clear args
+        record.msg = redacted_message
         record.args = ()
         return True
 

--- a/tools/poc-import/src/poc_import/cli_support.py
+++ b/tools/poc-import/src/poc_import/cli_support.py
@@ -4,11 +4,39 @@
 """Shared CLI helpers and console setup."""
 
 import logging
+import os
+import re
 
 from rich.console import Console
 from rich.logging import RichHandler
 
 console = Console()
+
+
+def redact_secrets(message: str) -> str:
+    """Redact secrets from log or error messages.
+
+    Args:
+        message: Message that may include secrets.
+
+    Returns:
+        Redacted message safe for display.
+    """
+    redacted = message
+    secret_keys = [
+        "WFP_JWT_TOKEN",
+        "JWT_SECRET_KEY",
+        "WFP_USER_ID",
+        "WFP_COMPANY_ID",
+    ]
+    for key in secret_keys:
+        value = os.getenv(key)
+        if value:
+            redacted = redacted.replace(value, "***")
+
+    jwt_pattern = re.compile(r"eyJ[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+")
+    redacted = jwt_pattern.sub("***", redacted)
+    return redacted
 
 
 def setup_logging(verbose: bool) -> None:

--- a/tools/poc-import/src/poc_import/cli_support.py
+++ b/tools/poc-import/src/poc_import/cli_support.py
@@ -3,14 +3,21 @@
 
 """Shared CLI helpers and console setup."""
 
+import contextvars
 import logging
 import os
 import re
+import time
 
 from rich.console import Console
 from rich.logging import RichHandler
 
 console = Console()
+
+_correlation_id_var: contextvars.ContextVar[str] = contextvars.ContextVar(
+    "correlation_id", default="-"
+)
+_base_log_record_factory = logging.getLogRecordFactory()
 
 
 def redact_secrets(message: str) -> str:
@@ -39,12 +46,67 @@ def redact_secrets(message: str) -> str:
     return redacted
 
 
-def setup_logging(verbose: bool) -> None:
+def set_correlation_id(correlation_id: str) -> None:
+    """Set correlation ID for the current command context."""
+    _correlation_id_var.set(correlation_id)
+
+
+def get_correlation_id() -> str:
+    """Get correlation ID for the current command context."""
+    return _correlation_id_var.get()
+
+
+class CorrelationIdFilter(logging.Filter):
+    """Attach correlation ID and redact secrets in log records."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        record.correlation_id = get_correlation_id()
+        message = record.getMessage()
+        redacted = redact_secrets(message)
+        record.msg = redacted
+        record.args = ()
+        return True
+
+
+def _record_factory(*args, **kwargs) -> logging.LogRecord:
+    record = _base_log_record_factory(*args, **kwargs)
+    if not hasattr(record, "correlation_id"):
+        record.correlation_id = get_correlation_id()
+    return record
+
+
+def log_duration(start_time: float, label: str, logger: logging.Logger) -> None:
+    """Log duration if operation exceeds 1 second.
+
+    Args:
+        start_time: Start timestamp from time.monotonic().
+        label: Operation label to log.
+        logger: Logger instance.
+    """
+    duration = time.monotonic() - start_time
+    if duration >= 1.0:
+        logger.info("Completed %s in %.2fs", label, duration)
+
+
+def setup_logging(verbose: bool, log_level: str | None = None) -> None:
     """Setup logging configuration for CLI commands."""
-    level = logging.DEBUG if verbose else logging.INFO
+    level_map = {
+        "debug": logging.DEBUG,
+        "info": logging.INFO,
+        "warning": logging.WARNING,
+        "error": logging.ERROR,
+        "critical": logging.CRITICAL,
+    }
+    if log_level:
+        level = level_map.get(log_level.lower(), logging.INFO)
+    else:
+        level = logging.DEBUG if verbose else logging.INFO
+    logging.setLogRecordFactory(_record_factory)
     logging.basicConfig(
         level=level,
-        format="%(message)s",
+        format="%(message)s [correlation_id=%(correlation_id)s]",
         datefmt="[%X]",
         handlers=[RichHandler(rich_tracebacks=True, console=console)],
+        force=True,
     )
+    logging.getLogger().addFilter(CorrelationIdFilter())

--- a/tools/poc-import/src/poc_import/cli_support.py
+++ b/tools/poc-import/src/poc_import/cli_support.py
@@ -68,7 +68,7 @@ class CorrelationIdFilter(logging.Filter):
         return True
 
 
-def _record_factory(*args, **kwargs) -> logging.LogRecord:
+def _record_factory(*args: object, **kwargs: object) -> logging.LogRecord:
     record = _base_log_record_factory(*args, **kwargs)
     if not hasattr(record, "correlation_id"):
         record.correlation_id = get_correlation_id()

--- a/tools/poc-import/src/poc_import/commands/excel.py
+++ b/tools/poc-import/src/poc_import/commands/excel.py
@@ -18,7 +18,11 @@ from poc_import.commands.rae import rae
     )
 )
 def excel() -> None:
-    """Excel-related commands."""
+    """Excel-related commands.
+
+    This command group provides subcommands for importing data from Excel files,
+    including expenses and RAE (Resource Assignment Estimates) data.
+    """
 
 
 excel.add_command(expenses)

--- a/tools/poc-import/src/poc_import/commands/excel.py
+++ b/tools/poc-import/src/poc_import/commands/excel.py
@@ -1,0 +1,25 @@
+# Copyright (c) 2026 Waterfall Project
+# SPDX-License-Identifier: Commercial
+
+"""Excel-related commands for the interactive shell."""
+
+import click
+
+from poc_import.commands.expenses import expenses
+from poc_import.commands.rae import rae
+
+
+@click.group(
+    help=(
+        "Manipulating Excel files and imports.\n\n"
+        "Commands:\n"
+        "  expenses  Import expenses from an Excel file\n"
+        "  rae       Import RAE from an Excel file"
+    )
+)
+def excel() -> None:
+    """Excel-related commands."""
+
+
+excel.add_command(expenses)
+excel.add_command(rae)

--- a/tools/poc-import/src/poc_import/commands/expenses.py
+++ b/tools/poc-import/src/poc_import/commands/expenses.py
@@ -5,12 +5,11 @@
 
 import sys
 from pathlib import Path
-from typing import Optional
 
 import click
 
 from poc_import.cli_support import console, setup_logging
-from poc_import.config import Config
+from poc_import.config import Config, load_env_file
 
 
 @click.command(help="Import expenses from an Excel file (not implemented).")
@@ -20,6 +19,12 @@ from poc_import.config import Config
     type=str,
     required=True,
     help="Project UUID",
+)
+@click.option(
+    "--env",
+    "env_name",
+    type=click.Choice(["dev", "staging", "prod"], case_sensitive=False),
+    help="Environment to load (.env.dev/.env.staging/.env.prod)",
 )
 @click.option(
     "--token",
@@ -48,13 +53,15 @@ from poc_import.config import Config
 def expenses(
     excel_file: Path,
     project_id: str,
-    token: Optional[str],
+    env_name: str | None,
+    token: str | None,
     api_url: str,
     dry_run: bool,
     verbose: bool,
 ) -> None:
     """Import expenses from Excel file."""
     setup_logging(verbose)
+    load_env_file(env_name)
     config = Config()
 
     api_url = api_url or config.api_url

--- a/tools/poc-import/src/poc_import/commands/expenses.py
+++ b/tools/poc-import/src/poc_import/commands/expenses.py
@@ -3,12 +3,20 @@
 
 """Excel expenses import command."""
 
+import logging
 import sys
+import time
+import uuid
 from pathlib import Path
 
 import click
 
-from poc_import.cli_support import console, setup_logging
+from poc_import.cli_support import (
+    console,
+    log_duration,
+    set_correlation_id,
+    setup_logging,
+)
 from poc_import.config import Config, load_env_file
 
 
@@ -45,6 +53,13 @@ from poc_import.config import Config, load_env_file
     help="Validate only, do not call API",
 )
 @click.option(
+    "--log-level",
+    type=click.Choice(
+        ["debug", "info", "warning", "error", "critical"], case_sensitive=False
+    ),
+    help="Logging level",
+)
+@click.option(
     "--verbose",
     "-v",
     is_flag=True,
@@ -57,11 +72,15 @@ def expenses(
     token: str | None,
     api_url: str,
     dry_run: bool,
+    log_level: str | None,
     verbose: bool,
 ) -> None:
     """Import expenses from Excel file."""
-    setup_logging(verbose)
+    setup_logging(verbose, log_level)
     load_env_file(env_name)
+    logger = logging.getLogger(__name__)
+    start_time = time.monotonic()
+    set_correlation_id(str(uuid.uuid4()))
     config = Config()
 
     api_url = api_url or config.api_url
@@ -82,4 +101,5 @@ def expenses(
     console.print("[yellow]⚠ Excel expenses import not yet implemented[/yellow]")
     console.print(f"  File: {excel_file}")
     console.print(f"  Project ID: {project_id}")
+    log_duration(start_time, "excel expenses", logger)
     sys.exit(0)

--- a/tools/poc-import/src/poc_import/commands/help_cmd.py
+++ b/tools/poc-import/src/poc_import/commands/help_cmd.py
@@ -165,6 +165,43 @@ def _print_service_help(topic: tuple[str, ...]) -> None:
     console.print(f"Unknown service help topic: {' '.join(topic)}")
 
 
+def _print_excel_help(topic: tuple[str, ...]) -> None:
+    """Print structured help for Excel commands."""
+    if not topic:
+        _print_header("Manipulating Excel files and imports")
+        _print_blank_line()
+        _print_header("Commands:")
+        _print_command_list(
+            [
+                "expenses  Import expenses from an Excel file",
+                "rae       Import RAE from an Excel file",
+            ]
+        )
+        return
+
+    if topic[0] == "expenses":
+        _print_header("Import expenses from Excel")
+        _print_blank_line()
+        _print_header("Parameters:")
+        _print_command_list(["excel_file"])
+        _print_blank_line()
+        _print_header("Example:")
+        console.print("  excel expenses ./expenses.xlsx --project-id <uuid>")
+        return
+
+    if topic[0] == "rae":
+        _print_header("Import RAE from Excel")
+        _print_blank_line()
+        _print_header("Parameters:")
+        _print_command_list(["excel_file"])
+        _print_blank_line()
+        _print_header("Example:")
+        console.print("  excel rae ./rae.xlsx --project-id <uuid>")
+        return
+
+    console.print(f"Unknown excel help topic: {' '.join(topic)}")
+
+
 @click.command(name="help", help="Show help for a command or topic.")
 @click.argument("topic", nargs=-1)
 @click.pass_context
@@ -180,6 +217,10 @@ def help_cmd(ctx: click.Context, topic: tuple[str, ...]) -> None:
 
     if topic[0] == "service":
         _print_service_help(topic[1:])
+        return
+
+    if topic[0] == "excel":
+        _print_excel_help(topic[1:])
         return
 
     command = _get_command(ctx, topic[0])

--- a/tools/poc-import/src/poc_import/commands/msproject.py
+++ b/tools/poc-import/src/poc_import/commands/msproject.py
@@ -5,6 +5,7 @@
 
 import logging
 import sys
+import time
 import uuid
 from pathlib import Path
 
@@ -12,7 +13,13 @@ import click
 from rich.progress import Progress, SpinnerColumn, TextColumn
 
 from poc_import.api.client import WfpApiClient, WfpApiError
-from poc_import.cli_support import console, redact_secrets, setup_logging
+from poc_import.cli_support import (
+    console,
+    log_duration,
+    redact_secrets,
+    set_correlation_id,
+    setup_logging,
+)
 from poc_import.config import Config, load_env_file
 from poc_import.models import ImportMode, ImportReport
 from poc_import.parsers.msproject import MSProjectParser, MSProjectParserError
@@ -66,6 +73,13 @@ from poc_import.validators import (
     help="Validate only, do not call API",
 )
 @click.option(
+    "--log-level",
+    type=click.Choice(
+        ["debug", "info", "warning", "error", "critical"], case_sensitive=False
+    ),
+    help="Logging level",
+)
+@click.option(
     "--verbose",
     "-v",
     is_flag=True,
@@ -85,6 +99,7 @@ def msproject(
     api_url: str,
     company_id: str | None,
     dry_run: bool,
+    log_level: str | None,
     verbose: bool,
     output_report: Path | None,
 ) -> None:
@@ -104,9 +119,10 @@ def msproject(
         # Dry run (validation only)
         poc-import msproject planning.xml --mode=initial --token=$TOKEN --dry-run
     """
-    setup_logging(verbose)
+    setup_logging(verbose, log_level)
     load_env_file(env_name)
     logger = logging.getLogger(__name__)
+    start_time = time.monotonic()
     config = Config()
 
     api_url = api_url or config.api_url
@@ -114,7 +130,8 @@ def msproject(
 
     # Generate correlation ID for tracing
     correlation_id = str(uuid.uuid4())
-    logger.info(f"Starting import [correlation_id={correlation_id}]")
+    set_correlation_id(correlation_id)
+    logger.info("Starting import")
 
     # Validate arguments
     if mode == "sync" and not project_id:
@@ -374,5 +391,7 @@ def msproject(
         sys.exit(1)
     except Exception as e:
         logger.exception("Unexpected error")
-        console.print(f"\n[red]✗ Unexpected error:[/red] {e}")
+        console.print(f"\n[red]✗ Unexpected error:[/red] {redact_secrets(str(e))}")
         sys.exit(3)
+    finally:
+        log_duration(start_time, "msproject command", logger)

--- a/tools/poc-import/src/poc_import/commands/msproject.py
+++ b/tools/poc-import/src/poc_import/commands/msproject.py
@@ -7,7 +7,6 @@ import logging
 import sys
 import uuid
 from pathlib import Path
-from typing import Optional
 
 import click
 from rich.progress import Progress, SpinnerColumn, TextColumn
@@ -24,7 +23,7 @@ from poc_import.validators import (
 )
 
 
-@click.command(help="Import MS Project XML into the API.")
+@click.command(help="Import MS Project XML file into the API.")
 @click.argument("xml_file", type=click.Path(exists=True, path_type=Path))
 @click.option(
     "--mode",
@@ -74,13 +73,13 @@ from poc_import.validators import (
 def msproject(
     xml_file: Path,
     mode: str,
-    project_id: Optional[str],
-    token: Optional[str],
+    project_id: str | None,
+    token: str | None,
     api_url: str,
-    company_id: Optional[str],
+    company_id: str | None,
     dry_run: bool,
     verbose: bool,
-    output_report: Optional[Path],
+    output_report: Path | None,
 ) -> None:
     """Import MS Project XML file.
 

--- a/tools/poc-import/src/poc_import/commands/msproject.py
+++ b/tools/poc-import/src/poc_import/commands/msproject.py
@@ -12,8 +12,8 @@ import click
 from rich.progress import Progress, SpinnerColumn, TextColumn
 
 from poc_import.api.client import WfpApiClient, WfpApiError
-from poc_import.cli_support import console, setup_logging
-from poc_import.config import Config
+from poc_import.cli_support import console, redact_secrets, setup_logging
+from poc_import.config import Config, load_env_file
 from poc_import.models import ImportMode, ImportReport
 from poc_import.parsers.msproject import MSProjectParser, MSProjectParserError
 from poc_import.validators import (
@@ -35,6 +35,12 @@ from poc_import.validators import (
     "--project-id",
     type=str,
     help="Existing project UUID (required for sync mode)",
+)
+@click.option(
+    "--env",
+    "env_name",
+    type=click.Choice(["dev", "staging", "prod"], case_sensitive=False),
+    help="Environment to load (.env.dev/.env.staging/.env.prod)",
 )
 @click.option(
     "--token",
@@ -74,6 +80,7 @@ def msproject(
     xml_file: Path,
     mode: str,
     project_id: str | None,
+    env_name: str | None,
     token: str | None,
     api_url: str,
     company_id: str | None,
@@ -98,6 +105,7 @@ def msproject(
         poc-import msproject planning.xml --mode=initial --token=$TOKEN --dry-run
     """
     setup_logging(verbose)
+    load_env_file(env_name)
     logger = logging.getLogger(__name__)
     config = Config()
 
@@ -191,7 +199,9 @@ def msproject(
             client.validate_token()
             console.print("[green]✓[/green] Authentication successful")
         except WfpApiError as e:
-            console.print(f"\n[red]✗ Authentication failed:[/red] {e}")
+            console.print(
+                f"\n[red]✗ Authentication failed:[/red] {redact_secrets(str(e))}"
+            )
             if e.status_code == 401:
                 console.print("  Check your JWT token and try again")
             sys.exit(2)

--- a/tools/poc-import/src/poc_import/commands/rae.py
+++ b/tools/poc-import/src/poc_import/commands/rae.py
@@ -5,12 +5,11 @@
 
 import sys
 from pathlib import Path
-from typing import Optional
 
 import click
 
 from poc_import.cli_support import console, setup_logging
-from poc_import.config import Config
+from poc_import.config import Config, load_env_file
 
 
 @click.command(help="Import RAE from an Excel file (not implemented).")
@@ -20,6 +19,12 @@ from poc_import.config import Config
     type=str,
     required=True,
     help="Project UUID",
+)
+@click.option(
+    "--env",
+    "env_name",
+    type=click.Choice(["dev", "staging", "prod"], case_sensitive=False),
+    help="Environment to load (.env.dev/.env.staging/.env.prod)",
 )
 @click.option(
     "--token",
@@ -48,13 +53,15 @@ from poc_import.config import Config
 def rae(
     excel_file: Path,
     project_id: str,
-    token: Optional[str],
+    env_name: str | None,
+    token: str | None,
     api_url: str,
     dry_run: bool,
     verbose: bool,
 ) -> None:
     """Import RAE (Reste À Engager) from Excel file."""
     setup_logging(verbose)
+    load_env_file(env_name)
     config = Config()
 
     api_url = api_url or config.api_url

--- a/tools/poc-import/src/poc_import/commands/rae.py
+++ b/tools/poc-import/src/poc_import/commands/rae.py
@@ -3,12 +3,20 @@
 
 """Excel RAE import command."""
 
+import logging
 import sys
+import time
+import uuid
 from pathlib import Path
 
 import click
 
-from poc_import.cli_support import console, setup_logging
+from poc_import.cli_support import (
+    console,
+    log_duration,
+    set_correlation_id,
+    setup_logging,
+)
 from poc_import.config import Config, load_env_file
 
 
@@ -45,6 +53,13 @@ from poc_import.config import Config, load_env_file
     help="Validate only, do not call API",
 )
 @click.option(
+    "--log-level",
+    type=click.Choice(
+        ["debug", "info", "warning", "error", "critical"], case_sensitive=False
+    ),
+    help="Logging level",
+)
+@click.option(
     "--verbose",
     "-v",
     is_flag=True,
@@ -57,11 +72,15 @@ def rae(
     token: str | None,
     api_url: str,
     dry_run: bool,
+    log_level: str | None,
     verbose: bool,
 ) -> None:
     """Import RAE (Reste À Engager) from Excel file."""
-    setup_logging(verbose)
+    setup_logging(verbose, log_level)
     load_env_file(env_name)
+    logger = logging.getLogger(__name__)
+    start_time = time.monotonic()
+    set_correlation_id(str(uuid.uuid4()))
     config = Config()
 
     api_url = api_url or config.api_url
@@ -82,4 +101,5 @@ def rae(
     console.print("[yellow]⚠ Excel RAE import not yet implemented[/yellow]")
     console.print(f"  File: {excel_file}")
     console.print(f"  Project ID: {project_id}")
+    log_duration(start_time, "excel rae", logger)
     sys.exit(0)

--- a/tools/poc-import/src/poc_import/commands/service.py
+++ b/tools/poc-import/src/poc_import/commands/service.py
@@ -3,13 +3,21 @@
 
 """Commands for interacting with the wfp-poc service."""
 
+import logging
 import sys
+import time
 import uuid
 
 import click
 
 from poc_import.api.client import WfpApiClient, WfpApiError
-from poc_import.cli_support import console, redact_secrets, setup_logging
+from poc_import.cli_support import (
+    console,
+    log_duration,
+    redact_secrets,
+    set_correlation_id,
+    setup_logging,
+)
 from poc_import.config import Config, load_env_file
 
 
@@ -39,10 +47,12 @@ def _build_client(
         )
         sys.exit(1)
 
+    correlation_id = str(uuid.uuid4())
+    set_correlation_id(correlation_id)
     return WfpApiClient(
         base_url=api_url,
         token=token,
-        correlation_id=str(uuid.uuid4()),
+        correlation_id=correlation_id,
         company_id=company_id,
     )
 
@@ -105,6 +115,13 @@ def service_projects() -> None:
     help="Company UUID for multi-tenant isolation (optional)",
 )
 @click.option(
+    "--log-level",
+    type=click.Choice(
+        ["debug", "info", "warning", "error", "critical"], case_sensitive=False
+    ),
+    help="Logging level",
+)
+@click.option(
     "--verbose",
     "-v",
     is_flag=True,
@@ -117,10 +134,13 @@ def service_projects_list(
     env_name: str | None,
     api_url: str,
     company_id: str | None,
+    log_level: str | None,
     verbose: bool,
 ) -> None:
     """List projects from the API."""
-    setup_logging(verbose)
+    setup_logging(verbose, log_level)
+    logger = logging.getLogger(__name__)
+    start_time = time.monotonic()
     client = _build_client(api_url, token, company_id, env_name)
 
     try:
@@ -139,6 +159,8 @@ def service_projects_list(
         name = item.get("name")
         code = item.get("code")
         console.print(f"- {project_id} | {name} | {code}")
+
+    log_duration(start_time, "service projects list", logger)
 
 
 @service.group(
@@ -189,6 +211,13 @@ def service_tasks() -> None:
     help="Company UUID for multi-tenant isolation (optional)",
 )
 @click.option(
+    "--log-level",
+    type=click.Choice(
+        ["debug", "info", "warning", "error", "critical"], case_sensitive=False
+    ),
+    help="Logging level",
+)
+@click.option(
     "--verbose",
     "-v",
     is_flag=True,
@@ -202,10 +231,13 @@ def service_tasks_list(
     env_name: str | None,
     api_url: str,
     company_id: str | None,
+    log_level: str | None,
     verbose: bool,
 ) -> None:
     """List tasks for a project."""
-    setup_logging(verbose)
+    setup_logging(verbose, log_level)
+    logger = logging.getLogger(__name__)
+    start_time = time.monotonic()
     client = _build_client(api_url, token, company_id, env_name)
 
     try:
@@ -228,3 +260,5 @@ def service_tasks_list(
         name = item.get("name")
         wbs = item.get("wbs") or ""
         console.print(f"- {task_id} | {name} | {wbs}")
+
+    log_duration(start_time, "service tasks list", logger)

--- a/tools/poc-import/src/poc_import/commands/service.py
+++ b/tools/poc-import/src/poc_import/commands/service.py
@@ -5,21 +5,22 @@
 
 import sys
 import uuid
-from typing import Optional
 
 import click
 
 from poc_import.api.client import WfpApiClient, WfpApiError
-from poc_import.cli_support import console, setup_logging
-from poc_import.config import Config
+from poc_import.cli_support import console, redact_secrets, setup_logging
+from poc_import.config import Config, load_env_file
 
 
 def _build_client(
     api_url: str,
-    token: Optional[str],
-    company_id: Optional[str],
+    token: str | None,
+    company_id: str | None,
+    env_name: str | None,
 ) -> WfpApiClient:
     """Build API client with configuration and token handling."""
+    load_env_file(env_name)
     config = Config()
 
     api_url = api_url or config.api_url
@@ -86,6 +87,12 @@ def service_projects() -> None:
     help="JWT authentication token (or set WFP_JWT_TOKEN env var)",
 )
 @click.option(
+    "--env",
+    "env_name",
+    type=click.Choice(["dev", "staging", "prod"], case_sensitive=False),
+    help="Environment to load (.env.dev/.env.staging/.env.prod)",
+)
+@click.option(
     "--api-url",
     type=str,
     envvar="WFP_API_URL",
@@ -104,21 +111,22 @@ def service_projects() -> None:
     help="Enable verbose logging",
 )
 def service_projects_list(
-    page: Optional[int],
-    per_page: Optional[int],
-    token: Optional[str],
+    page: int | None,
+    per_page: int | None,
+    token: str | None,
+    env_name: str | None,
     api_url: str,
-    company_id: Optional[str],
+    company_id: str | None,
     verbose: bool,
 ) -> None:
     """List projects from the API."""
     setup_logging(verbose)
-    client = _build_client(api_url, token, company_id)
+    client = _build_client(api_url, token, company_id, env_name)
 
     try:
         result = client.list_projects(page=page, per_page=per_page)
     except WfpApiError as e:
-        console.print(f"[red]Error:[/red] {e}")
+        console.print(f"[red]Error:[/red] {redact_secrets(str(e))}")
         sys.exit(2)
 
     items = result.get("data", [])
@@ -163,6 +171,12 @@ def service_tasks() -> None:
     help="JWT authentication token (or set WFP_JWT_TOKEN env var)",
 )
 @click.option(
+    "--env",
+    "env_name",
+    type=click.Choice(["dev", "staging", "prod"], case_sensitive=False),
+    help="Environment to load (.env.dev/.env.staging/.env.prod)",
+)
+@click.option(
     "--api-url",
     type=str,
     envvar="WFP_API_URL",
@@ -182,16 +196,17 @@ def service_tasks() -> None:
 )
 def service_tasks_list(
     project_id: str,
-    page: Optional[int],
-    per_page: Optional[int],
-    token: Optional[str],
+    page: int | None,
+    per_page: int | None,
+    token: str | None,
+    env_name: str | None,
     api_url: str,
-    company_id: Optional[str],
+    company_id: str | None,
     verbose: bool,
 ) -> None:
     """List tasks for a project."""
     setup_logging(verbose)
-    client = _build_client(api_url, token, company_id)
+    client = _build_client(api_url, token, company_id, env_name)
 
     try:
         result = client.list_project_tasks(
@@ -200,7 +215,7 @@ def service_tasks_list(
             per_page=per_page,
         )
     except WfpApiError as e:
-        console.print(f"[red]Error:[/red] {e}")
+        console.print(f"[red]Error:[/red] {redact_secrets(str(e))}")
         sys.exit(2)
 
     items = result.get("data", [])

--- a/tools/poc-import/src/poc_import/config.py
+++ b/tools/poc-import/src/poc_import/config.py
@@ -14,31 +14,49 @@ from dotenv import load_dotenv
 from pydantic import BaseModel, ConfigDict, Field
 
 
-def _load_env_file() -> None:
-    """Load poc-import environment file if present."""
+def load_env_file(env_name: str | None = None, *, override: bool = True) -> None:
+    """Load poc-import environment file if present.
+
+    Args:
+        env_name: Optional environment name (dev/staging/prod).
+        override: Whether to override existing environment variables.
+    """
     repo_root = Path(__file__).resolve().parents[4]
+
+    if env_name:
+        env_filename = f".env.{env_name}"
+        candidate_paths = [
+            (Path.cwd() / env_filename).resolve(),
+            (repo_root / env_filename).resolve(),
+            (repo_root / "tools" / "poc-import" / env_filename).resolve(),
+        ]
+        for path in candidate_paths:
+            if path.exists():
+                load_dotenv(path, override=override)
+                return
+
     env_value = os.getenv("WFP_ENV_FILE")
     if env_value:
         env_path = Path(env_value)
         if not env_path.is_absolute():
             cwd_path = (Path.cwd() / env_path).resolve()
             if cwd_path.exists():
-                load_dotenv(cwd_path)
+                load_dotenv(cwd_path, override=override)
                 return
             repo_path = (repo_root / env_path).resolve()
             if repo_path.exists():
-                load_dotenv(repo_path)
+                load_dotenv(repo_path, override=override)
                 return
         if env_path.exists():
-            load_dotenv(env_path)
+            load_dotenv(env_path, override=override)
         return
 
     default_path = repo_root / "tools" / "poc-import" / ".env"
     if default_path.exists():
-        load_dotenv(default_path)
+        load_dotenv(default_path, override=override)
 
 
-_load_env_file()
+load_env_file()
 
 
 class Config(BaseModel):

--- a/tools/poc-import/src/poc_import/config.py
+++ b/tools/poc-import/src/poc_import/config.py
@@ -11,7 +11,7 @@ from pathlib import Path
 
 import jwt
 from dotenv import load_dotenv
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 def _load_env_file() -> None:
@@ -43,6 +43,8 @@ _load_env_file()
 
 class Config(BaseModel):
     """Application configuration."""
+
+    model_config = ConfigDict(frozen=True)
 
     api_url: str = Field(
         default_factory=lambda: os.getenv("WFP_API_URL", "http://localhost:5000"),
@@ -103,8 +105,3 @@ class Config(BaseModel):
         }
         token = jwt.encode(payload, self.jwt_secret_key, algorithm=self.jwt_algorithm)
         return token if isinstance(token, str) else token.decode("utf-8")
-
-    class Config:
-        """Pydantic config."""
-
-        frozen = True

--- a/tools/poc-import/src/poc_import/models.py
+++ b/tools/poc-import/src/poc_import/models.py
@@ -5,7 +5,6 @@
 
 from datetime import datetime
 from enum import Enum
-from typing import Optional
 from uuid import UUID
 
 from pydantic import BaseModel, Field
@@ -39,10 +38,10 @@ class ProjectMetadata(BaseModel):
     """MS Project metadata."""
 
     name: str
-    title: Optional[str] = None
+    title: str | None = None
     start_date: datetime
     finish_date: datetime
-    guid: Optional[str] = None
+    guid: str | None = None
 
 
 class TaskPredecessor(BaseModel):
@@ -57,15 +56,15 @@ class Task(BaseModel):
     """MS Project task."""
 
     uid: int
-    guid: Optional[str] = None
+    guid: str | None = None
     name: str
-    wbs_code: Optional[str] = None
+    wbs_code: str | None = None
     is_summary: bool = False
     is_milestone: bool = False
-    planned_start_date: Optional[datetime] = None
-    planned_finish_date: Optional[datetime] = None
-    duration_hours: Optional[float] = None
-    budget: Optional[float] = None
+    planned_start_date: datetime | None = None
+    planned_finish_date: datetime | None = None
+    duration_hours: float | None = None
+    budget: float | None = None
     percent_complete: float = 0
     is_critical: bool = False
     predecessors: list[TaskPredecessor] = Field(default_factory=list)
@@ -75,10 +74,10 @@ class Resource(BaseModel):
     """MS Project resource."""
 
     uid: int
-    guid: Optional[str] = None
+    guid: str | None = None
     name: str
     type: ResourceType
-    standard_rate: Optional[float] = None
+    standard_rate: float | None = None
     max_units: float = 1.0
 
 
@@ -111,5 +110,5 @@ class ImportReport(BaseModel):
     failed_count: int = 0
     validation_errors: list[str] = Field(default_factory=list)
     api_errors: list[str] = Field(default_factory=list)
-    project_id: Optional[UUID] = None
+    project_id: UUID | None = None
     timestamp: datetime = Field(default_factory=datetime.utcnow)

--- a/tools/poc-import/src/poc_import/parsers/msproject.py
+++ b/tools/poc-import/src/poc_import/parsers/msproject.py
@@ -5,7 +5,6 @@
 
 import logging
 from datetime import datetime
-from typing import Optional
 
 from lxml import etree
 from pydantic import ValidationError
@@ -39,8 +38,8 @@ class MSProjectParser:
     def __init__(self, xml_path: str) -> None:
         """Initialize parser with XML file path."""
         self.xml_path = xml_path
-        self.tree: Optional[etree._ElementTree] = None
-        self.root: Optional[etree._Element] = None
+        self.tree: etree._ElementTree | None = None
+        self.root: etree._Element | None = None
 
     def parse(self) -> MSProjectData:
         """Parse MS Project XML file."""
@@ -50,10 +49,8 @@ class MSProjectParser:
 
             project = self._parse_project_metadata()
             tasks = self._parse_tasks()
-            # resources = self._parse_resources()
-            # assignments = self._parse_assignments()
-            resources: list[Resource] = []
-            assignments: list[Assignment] = []
+            resources = self._parse_resources()
+            assignments = self._parse_assignments()
 
             logger.info(
                 f"Parsed MS Project: {len(tasks)} tasks, "
@@ -118,7 +115,7 @@ class MSProjectParser:
 
         return tasks
 
-    def _parse_task(self, elem: etree._Element) -> Optional[Task]:
+    def _parse_task(self, elem: etree._Element) -> Task | None:
         """Parse single task element."""
         uid_text = elem.findtext(f"{NS}UID")
         if not uid_text or uid_text == "0":
@@ -169,27 +166,30 @@ class MSProjectParser:
         """Parse predecessor links for a task."""
         predecessors: list[TaskPredecessor] = []
 
-        pred_elem = elem.find(f"{NS}PredecessorLink")
-        if pred_elem is not None:
+        for pred_elem in elem.findall(f"{NS}PredecessorLink"):
             uid_text = pred_elem.findtext(f"{NS}PredecessorUID")
-            if uid_text and uid_text != "0":
-                pred_uid = int(uid_text)
-                type_text = pred_elem.findtext(f"{NS}Type", default="1")
-                type_map = {
-                    "0": DependencyType.SS,
-                    "1": DependencyType.FS,
-                    "2": DependencyType.FF,
-                    "3": DependencyType.SF,
-                }
-                dep_type = type_map.get(type_text, DependencyType.FS)
-                lag_text = pred_elem.findtext(f"{NS}LinkLag", default="0")
-                lag = int(lag_text)
+            if not uid_text or uid_text == "0":
+                continue
 
-                predecessors.append(
-                    TaskPredecessor(
-                        predecessor_task_uid=pred_uid, type=dep_type, lag=lag
-                    )
+            pred_uid = int(uid_text)
+            type_text = pred_elem.findtext(f"{NS}Type", default="1")
+            type_map = {
+                "0": DependencyType.SS,
+                "1": DependencyType.FS,
+                "2": DependencyType.FF,
+                "3": DependencyType.SF,
+            }
+            dep_type = type_map.get(type_text, DependencyType.FS)
+            lag_text = pred_elem.findtext(f"{NS}LinkLag", default="0")
+            lag = int(lag_text)
+
+            predecessors.append(
+                TaskPredecessor(
+                    predecessor_task_uid=pred_uid,
+                    type=dep_type,
+                    lag=lag,
                 )
+            )
 
         return predecessors
 
@@ -215,7 +215,7 @@ class MSProjectParser:
 
         return resources
 
-    def _parse_resource(self, elem: etree._Element) -> Optional[Resource]:
+    def _parse_resource(self, elem: etree._Element) -> Resource | None:
         """Parse single resource element."""
         uid_text = elem.findtext(f"{NS}UID")
         if not uid_text or uid_text == "0":
@@ -269,7 +269,7 @@ class MSProjectParser:
 
         return assignments
 
-    def _parse_assignment(self, elem: etree._Element) -> Optional[Assignment]:
+    def _parse_assignment(self, elem: etree._Element) -> Assignment | None:
         """Parse single assignment element."""
         task_uid_text = elem.findtext(f"{NS}TaskUID")
         resource_uid_text = elem.findtext(f"{NS}ResourceUID")
@@ -293,18 +293,14 @@ class MSProjectParser:
             units=units,
         )
 
-    def _get_text(
-        self, element_name: str, default: Optional[str] = None
-    ) -> Optional[str]:
+    def _get_text(self, element_name: str, default: str | None = None) -> str | None:
         """Get text content of element."""
         if self.root is None:
             return default
-        result: Optional[str] = self.root.findtext(
-            f"{NS}{element_name}", default=default
-        )
+        result: str | None = self.root.findtext(f"{NS}{element_name}", default=default)
         return result
 
-    def _parse_datetime(self, date_str: Optional[str]) -> Optional[datetime]:
+    def _parse_datetime(self, date_str: str | None) -> datetime | None:
         """Parse MS Project datetime string."""
         if not date_str:
             return None

--- a/tools/poc-import/src/poc_import/shell_state.py
+++ b/tools/poc-import/src/poc_import/shell_state.py
@@ -5,7 +5,6 @@
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
 
 from poc_import.models import MSProjectData
 
@@ -14,5 +13,5 @@ from poc_import.models import MSProjectData
 class ShellState:
     """State for interactive shell session."""
 
-    xml_path: Optional[Path] = None
-    data: Optional[MSProjectData] = None
+    xml_path: Path | None = None
+    data: MSProjectData | None = None

--- a/tools/poc-import/src/poc_import/validators.py
+++ b/tools/poc-import/src/poc_import/validators.py
@@ -4,7 +4,7 @@
 """Validation logic for import data and business rules."""
 
 import logging
-from typing import Any, Optional
+from typing import Any
 
 from poc_import.models import MSProjectData, Task
 
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 class ValidationError(Exception):
     """Base exception for validation errors."""
 
-    def __init__(self, message: str, errors: Optional[list[dict[str, Any]]] = None):
+    def __init__(self, message: str, errors: list[dict[str, Any]] | None = None):
         super().__init__(message)
         self.errors = errors or []
 

--- a/tools/poc-import/tests/test_api_client.py
+++ b/tools/poc-import/tests/test_api_client.py
@@ -10,6 +10,7 @@ import pytest
 import requests_mock
 
 from poc_import.api.client import WfpApiClient, WfpApiError
+from poc_import.commands.service import _build_client
 from poc_import.models import (
     Assignment,
     MSProjectData,
@@ -252,6 +253,25 @@ def test_create_assignments_bulk_success(api_client, sample_assignment):
 
     with pytest.raises(WfpApiError, match="requires UID->UUID mapping"):
         api_client.create_assignments_bulk(project_id, assignments)
+
+
+def test_service_build_client_token_override(monkeypatch):
+    """Test that explicit token overrides env token.
+
+    Given: WFP_JWT_TOKEN is set in environment
+    When: _build_client is called with a token argument
+    Then: The client uses the explicit token
+    """
+    monkeypatch.setenv("WFP_JWT_TOKEN", "env-token")
+
+    client = _build_client(
+        api_url="http://localhost:5000",
+        token="override-token",
+        company_id=None,
+        env_name=None,
+    )
+
+    assert client.token == "override-token"
 
 
 def test_import_msproject_data_initial(

--- a/tools/poc-import/tests/test_api_client.py
+++ b/tools/poc-import/tests/test_api_client.py
@@ -3,7 +3,7 @@
 
 """Tests for API client."""
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from uuid import uuid4
 
 import pytest
@@ -35,8 +35,8 @@ def sample_project():
     """Create sample project metadata."""
     return ProjectMetadata(
         name="Test Project",
-        start_date=datetime(2026, 1, 1, tzinfo=timezone.utc),
-        finish_date=datetime(2026, 12, 31, tzinfo=timezone.utc),
+        start_date=datetime(2026, 1, 1, tzinfo=UTC),
+        finish_date=datetime(2026, 12, 31, tzinfo=UTC),
         guid=str(uuid4()),
     )
 
@@ -48,8 +48,8 @@ def sample_task():
         uid=1,
         name="Test Task",
         wbs_code="1.1",
-        planned_start_date=datetime(2026, 1, 1, tzinfo=timezone.utc),
-        planned_finish_date=datetime(2026, 1, 31, tzinfo=timezone.utc),
+        planned_start_date=datetime(2026, 1, 1, tzinfo=UTC),
+        planned_finish_date=datetime(2026, 1, 31, tzinfo=UTC),
         duration_hours=160,
         is_milestone=False,
         guid=str(uuid4()),
@@ -160,7 +160,7 @@ def test_get_project_milestones_success(api_client):
         m.get(
             f"http://localhost:5000/v0/projects/{project_id}/milestones",
             json={
-                "milestones": [
+                "data": [
                     {"id": str(uuid4()), "name": "Milestone 1"},
                     {"id": str(uuid4()), "name": "Milestone 2"},
                 ]
@@ -250,12 +250,8 @@ def test_create_assignments_bulk_success(api_client, sample_assignment):
     project_id = str(uuid4())
     assignments = [sample_assignment]
 
-    result = api_client.create_assignments_bulk(project_id, assignments)
-
-    # Assignments not implemented - should return failed
-    assert result["created_count"] == 0
-    assert result["failed_count"] == 1
-    assert len(result["errors"]) == 1
+    with pytest.raises(WfpApiError, match="requires UID->UUID mapping"):
+        api_client.create_assignments_bulk(project_id, assignments)
 
 
 def test_import_msproject_data_initial(

--- a/tools/poc-import/tests/test_cli.py
+++ b/tools/poc-import/tests/test_cli.py
@@ -147,3 +147,37 @@ class TestCLI:
             assert "not yet implemented" in result.output
         finally:
             Path(tmp_path).unlink()
+
+    def test_msproject_missing_token_error(
+        self, sample_msproject_xml, monkeypatch, tmp_path
+    ):
+        """Test msproject error when token is missing.
+
+        Given: No JWT token is available in env
+        When: msproject runs without --token
+        Then: A clear error is shown
+        """
+        runner = CliRunner()
+        monkeypatch.delenv("WFP_JWT_TOKEN", raising=False)
+        monkeypatch.delenv("JWT_SECRET_KEY", raising=False)
+        monkeypatch.delenv("WFP_USER_ID", raising=False)
+        monkeypatch.delenv("WFP_COMPANY_ID", raising=False)
+        monkeypatch.setenv("WFP_ENV_FILE", str(tmp_path / "missing.env"))
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".xml", delete=False) as tmp:
+            tmp.write(sample_msproject_xml)
+            tmp_path = tmp.name
+
+        try:
+            result = runner.invoke(
+                cli,
+                [
+                    "msproject",
+                    tmp_path,
+                    "--mode=initial",
+                ],
+            )
+            assert result.exit_code == 1
+            assert "--token is required" in result.output
+        finally:
+            Path(tmp_path).unlink()

--- a/tools/poc-import/tests/test_cli.py
+++ b/tools/poc-import/tests/test_cli.py
@@ -166,18 +166,18 @@ class TestCLI:
 
         with tempfile.NamedTemporaryFile(mode="w", suffix=".xml", delete=False) as tmp:
             tmp.write(sample_msproject_xml)
-            tmp_path = tmp.name
+            xml_file_path = tmp.name
 
         try:
             result = runner.invoke(
                 cli,
                 [
                     "msproject",
-                    tmp_path,
+                    xml_file_path,
                     "--mode=initial",
                 ],
             )
             assert result.exit_code == 1
             assert "--token is required" in result.output
         finally:
-            Path(tmp_path).unlink()
+            Path(xml_file_path).unlink()

--- a/tools/poc-import/tests/test_cli.py
+++ b/tools/poc-import/tests/test_cli.py
@@ -28,6 +28,7 @@ class TestCLI:
         assert result.exit_code == 0
         assert "poc-import" in result.output
         assert "msproject" in result.output
+        assert "excel" in result.output
 
     def test_msproject_help(self):
         """Test msproject subcommand help."""
@@ -112,6 +113,7 @@ class TestCLI:
             result = runner.invoke(
                 cli,
                 [
+                    "excel",
                     "expenses",
                     tmp_path,
                     "--project-id=12345678-1234-1234-1234-123456789012",
@@ -134,6 +136,7 @@ class TestCLI:
             result = runner.invoke(
                 cli,
                 [
+                    "excel",
                     "rae",
                     tmp_path,
                     "--project-id=12345678-1234-1234-1234-123456789012",

--- a/tools/poc-import/tests/test_cli_support.py
+++ b/tools/poc-import/tests/test_cli_support.py
@@ -1,0 +1,39 @@
+# Copyright (c) 2026 Waterfall Project
+# SPDX-License-Identifier: Commercial
+
+"""Tests for CLI support helpers."""
+
+from __future__ import annotations
+
+from poc_import.cli_support import redact_secrets
+
+
+def test_redact_secrets_env_values(monkeypatch):
+    """Test redacting environment secret values.
+
+    Given: Secret values in environment variables
+    When: redact_secrets() is called
+    Then: Secrets are masked in the output
+    """
+    monkeypatch.setenv("WFP_JWT_TOKEN", "env-token")
+    message = "token=env-token"
+
+    result = redact_secrets(message)
+
+    assert "env-token" not in result
+    assert "***" in result
+
+
+def test_redact_secrets_jwt_pattern():
+    """Test redacting JWT-like strings.
+
+    Given: A JWT-like token in the message
+    When: redact_secrets() is called
+    Then: The token is masked
+    """
+    message = "auth=eyJabc.def123.ghi456"
+
+    result = redact_secrets(message)
+
+    assert "eyJabc.def123.ghi456" not in result
+    assert "***" in result

--- a/tools/poc-import/tests/test_config.py
+++ b/tools/poc-import/tests/test_config.py
@@ -1,0 +1,28 @@
+# Copyright (c) 2026 Waterfall Project
+# SPDX-License-Identifier: Commercial
+
+"""Tests for configuration loading."""
+
+from __future__ import annotations
+
+import os
+
+from poc_import.config import load_env_file
+
+
+def test_load_env_file_dev(tmp_path, monkeypatch):
+    """Test loading environment-specific .env file.
+
+    Given: A .env.dev file in the current working directory
+    When: load_env_file("dev") is called
+    Then: The environment variables are loaded
+    """
+    env_file = tmp_path / ".env.dev"
+    env_file.write_text("WFP_JWT_TOKEN=from_env\n")
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("WFP_JWT_TOKEN", raising=False)
+
+    load_env_file("dev")
+
+    assert os.getenv("WFP_JWT_TOKEN") == "from_env"

--- a/tools/poc-import/tests/test_validators.py
+++ b/tools/poc-import/tests/test_validators.py
@@ -3,7 +3,7 @@
 
 """Tests for validators."""
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from uuid import uuid4
 
 import pytest
@@ -30,8 +30,8 @@ def valid_project():
     """Create valid project metadata."""
     return ProjectMetadata(
         name="Test Project",
-        start_date=datetime(2026, 1, 1, tzinfo=timezone.utc),
-        finish_date=datetime(2026, 12, 31, tzinfo=timezone.utc),
+        start_date=datetime(2026, 1, 1, tzinfo=UTC),
+        finish_date=datetime(2026, 12, 31, tzinfo=UTC),
         guid=str(uuid4()),
     )
 
@@ -43,8 +43,8 @@ def valid_task():
         uid=1,
         name="Test Task",
         wbs_code="1.1",
-        planned_start_date=datetime(2026, 1, 1, tzinfo=timezone.utc),
-        planned_finish_date=datetime(2026, 1, 31, tzinfo=timezone.utc),
+        planned_start_date=datetime(2026, 1, 1, tzinfo=UTC),
+        planned_finish_date=datetime(2026, 1, 31, tzinfo=UTC),
         duration_hours=160,
         is_milestone=False,
         guid=str(uuid4()),
@@ -58,8 +58,8 @@ def valid_milestone():
         uid=2,
         name="Milestone 1",
         wbs_code="1.0",
-        planned_start_date=datetime(2026, 1, 31, tzinfo=timezone.utc),
-        planned_finish_date=datetime(2026, 1, 31, tzinfo=timezone.utc),
+        planned_start_date=datetime(2026, 1, 31, tzinfo=UTC),
+        planned_finish_date=datetime(2026, 1, 31, tzinfo=UTC),
         duration_hours=0,
         is_milestone=True,
         guid=str(uuid4()),
@@ -170,7 +170,7 @@ def test_validate_msproject_data_empty_project_name(valid_project, valid_task):
 
 def test_validate_msproject_data_invalid_dates(valid_project, valid_task):
     """Test validation with invalid dates."""
-    valid_project.finish_date = datetime(2025, 1, 1, tzinfo=timezone.utc)
+    valid_project.finish_date = datetime(2025, 1, 1, tzinfo=UTC)
     data = MSProjectData(
         project=valid_project, tasks=[valid_task], resources=[], assignments=[]
     )
@@ -231,8 +231,8 @@ def test_validate_msproject_data_duplicate_task_uid(valid_project, valid_task):
         uid=1,  # Duplicate UID
         name="Task 2",
         wbs_code="1.2",
-        planned_start_date=datetime(2026, 2, 1, tzinfo=timezone.utc),
-        planned_finish_date=datetime(2026, 2, 28, tzinfo=timezone.utc),
+        planned_start_date=datetime(2026, 2, 1, tzinfo=UTC),
+        planned_finish_date=datetime(2026, 2, 28, tzinfo=UTC),
         duration_hours=160,
         is_milestone=False,
     )


### PR DESCRIPTION
## Summary
- align poc-import CLI bootstrap with spec (excel group, help, python 3.11+, parser/resources/assignments)
- implement config/JWT handling with env selection and secret redaction
- add logging controls with correlation IDs and duration logging
- add targeted tests for issues 71/72 and fix lint/type checks

## Testing
- pytest /home/benjamin/projects/wfp-poc/tools/poc-import/tests
- make lint
- make type-check

## Issues
- Closes #71, #72, #73