### PR TITLE
fix(poc-import): correct MS Project dependency type mapping

### DIFF
--- a/tools/poc-import/src/poc_import/parsers/msproject.py
+++ b/tools/poc-import/src/poc_import/parsers/msproject.py
@@ -205,10 +205,10 @@ class MSProjectParser:
             pred_uid = int(uid_text)
             type_text = pred_elem.findtext(f"{NS}Type", default="1")
             type_map = {
-                "0": DependencyType.FF,
+                "0": DependencyType.SS,
                 "1": DependencyType.FS,
-                "2": DependencyType.SF,
-                "3": DependencyType.SS,
+                "2": DependencyType.FF,
+                "3": DependencyType.SF,
             }
             dep_type = type_map.get(type_text, DependencyType.FS)
             lag_text = pred_elem.findtext(f"{NS}LinkLag", default="0")

--- a/tools/poc-import/tests/test_msproject_parser.py
+++ b/tools/poc-import/tests/test_msproject_parser.py
@@ -136,6 +136,63 @@ class TestMSProjectParser:
         # Test invalid duration
         assert parser._parse_duration("invalid") == pytest.approx(0.0)
 
+    def test_parse_dependency_types(self, sample_msproject_xml):
+        """Test parsing dependency types.
+
+        Given: MS Project XML with all dependency type values
+        When: The parser processes the predecessor links
+        Then: Each dependency type maps to the correct enum value
+        """
+        original_link = """            <PredecessorLink>
+                <PredecessorUID>1</PredecessorUID>
+                <Type>1</Type>
+                <LinkLag>0</LinkLag>
+            </PredecessorLink>"""
+        replacement_links = """            <PredecessorLink>
+                <PredecessorUID>1</PredecessorUID>
+                <Type>0</Type>
+                <LinkLag>0</LinkLag>
+            </PredecessorLink>
+            <PredecessorLink>
+                <PredecessorUID>1</PredecessorUID>
+                <Type>1</Type>
+                <LinkLag>0</LinkLag>
+            </PredecessorLink>
+            <PredecessorLink>
+                <PredecessorUID>1</PredecessorUID>
+                <Type>2</Type>
+                <LinkLag>0</LinkLag>
+            </PredecessorLink>
+            <PredecessorLink>
+                <PredecessorUID>1</PredecessorUID>
+                <Type>3</Type>
+                <LinkLag>0</LinkLag>
+            </PredecessorLink>"""
+
+        xml_with_types = sample_msproject_xml.replace(original_link, replacement_links)
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".xml", delete=False) as tmp:
+            tmp.write(xml_with_types)
+            tmp_path = tmp.name
+
+        try:
+            parser = MSProjectParser(tmp_path)
+            data = parser.parse()
+
+            task2 = data.tasks[1]
+            expected_types = [
+                DependencyType.SS,
+                DependencyType.FS,
+                DependencyType.FF,
+                DependencyType.SF,
+            ]
+            assert [pred.type for pred in task2.predecessors] == expected_types
+
+            dependency_types = [dep.type for dep in data.dependencies]
+            assert dependency_types == expected_types
+        finally:
+            Path(tmp_path).unlink()
+
     def test_parse_sample_file(self, sample_xml_path):
         """Test parsing sample MS Project XML file."""
         xml_path = Path(sample_xml_path)


### PR DESCRIPTION
## Description
Corrige un bug critique dans le mapping des types de dépendances MS Project identifié lors de la review de PR #89.

## Problem
Le mapping actuel était incorrect :
- 0 → FF ❌ (devrait être SS)
- 1 → FS ✅ (correct)
- 2 → SF ❌ (devrait être FF)
- 3 → SS ❌ (devrait être SF)

## Solution
Correction du mapping selon la documentation MS Project et les commentaires dans `DependencyType` enum :
- 0 → SS (Start-to-Start)
- 1 → FS (Finish-to-Start)
- 2 → FF (Finish-to-Finish)
- 3 → SF (Start-to-Finish)

## Impact
Sans ce fix, toutes les dépendances importées depuis MS Project XML ont des types incorrects (sauf FS qui était correct).

## Related
Fixes issue identified in #89 review comment by @copilot-pull-request-reviewer